### PR TITLE
Test/change save param

### DIFF
--- a/main/main_robot.cpp
+++ b/main/main_robot.cpp
@@ -66,7 +66,7 @@ void app_main(void)
   esp_log_level_set("BLEServerService", ESP_LOG_DEBUG);
   esp_log_level_set("Main", ESP_LOG_DEBUG);
   // esp_log_level_set("SensorsService", ESP_LOG_DEBUG);
-  // esp_log_level_set("SpeedService", ESP_LOG_DEBUG);
+  //esp_log_level_set("SpeedService", ESP_LOG_DEBUG);
 
   ESP_LOGD("Main", "Configurando Comandos...");
   better_console_config_t console_config;

--- a/modules/common/components/CMDWrapper/cmd_param/cmd_param.cpp
+++ b/modules/common/components/CMDWrapper/cmd_param/cmd_param.cpp
@@ -264,8 +264,13 @@ static std::string param_set(int argc, char **argv)
     }
 
     ESP_LOGD(name, "Definido parâmetro local %s com valor %s", param_set_args.name->sval[0], param_set_args.value->sval[0]);
-    DataManager::getInstance()->setParam(param_set_args.name->sval[0], param_set_args.value->sval[0]);
-
+    CarState state = (CarState)Robot::getInstance()->getStatus()->robotState->getData();
+    if(state == CAR_STOPPED) DataManager::getInstance()->setParam(param_set_args.name->sval[0], param_set_args.value->sval[0]);
+    else 
+    {
+        DataManager::getInstance()->setParam(param_set_args.name->sval[0], param_set_args.value->sval[0],false);
+        DataManager::getInstance()->registerParamDataChanged(param_set_args.name->sval[0]);
+    }
     return "OK";
 }
 

--- a/modules/common/components/DataObjects/src/DataManager.cpp
+++ b/modules/common/components/DataObjects/src/DataManager.cpp
@@ -72,7 +72,7 @@ void DataManager::setParam(std::string name, std::string value)
         if (data->getName() == name)
         {
             data->setData(value);
-            data->saveData();
+            //data->saveData();
             return;
         }
     }

--- a/modules/common/components/DataObjects/src/DataManager.hpp
+++ b/modules/common/components/DataObjects/src/DataManager.hpp
@@ -37,12 +37,14 @@ public:
     };
 
     void registerParamData(IDataAbstract *data);
+    void registerParamDataChanged(std::string name);
     void registerRuntimeData(IDataAbstract *data);
 
     void saveAllParamData();
+    void saveAllParamDataChanged();
     void saveAllRuntimeData();
 
-    void setParam(std::string name, std::string value);
+    void setParam(std::string name, std::string value, bool savedata = true);
     std::string getParam(std::string name, std::string ctrl);
 
     void loadAllParamData();
@@ -58,8 +60,12 @@ private:
     static std::vector<IDataAbstract *> dataParamList;
     static std::mutex dataParamListMutex;
 
+
     static std::vector<IDataAbstract *> dataRuntimeList;
     static std::mutex dataRuntimeListMutex;
+
+    std::vector<IDataAbstract *> dataParamChangedList;
+    std::mutex dataParamChangedListMutex;
 
     static std::string name;
 

--- a/modules/robot/components/RobotData/src/SLatMarks/dataSLatMarks.cpp
+++ b/modules/robot/components/RobotData/src/SLatMarks/dataSLatMarks.cpp
@@ -21,7 +21,7 @@ dataSLatMarks::dataSLatMarks(std::string name)
     thresholdToCurve = new DataAbstract<uint8_t>("thresholdToCurve", name, 25);
     dataManager->registerParamData(thresholdToCurve);
 
-    MarkstoStop = new DataAbstract<uint8_t>("MarkstoStop", name, 2);
+    MarkstoStop = new DataAbstract<uint16_t>("MarkstoStop", name, 2);
     dataManager->registerParamData(MarkstoStop);
 
     PulsesBeforeCurve = new DataAbstract<uint32_t>("PulsesBeforeCurve", name, 200);

--- a/modules/robot/components/RobotData/src/SLatMarks/dataSLatMarks.h
+++ b/modules/robot/components/RobotData/src/SLatMarks/dataSLatMarks.h
@@ -46,7 +46,7 @@ public:
     // Parâmetros
 
     //Número de marcações direita para a parada 
-    DataAbstract<uint8_t> *MarkstoStop;
+    DataAbstract<uint16_t> *MarkstoStop;
     //Pulsos antes de inicar uma curva para iniciar a desaceleração
     DataAbstract<uint32_t> *PulsesBeforeCurve;
 

--- a/modules/robot/services/CarStatusService/src/CarStatusService.cpp
+++ b/modules/robot/services/CarStatusService/src/CarStatusService.cpp
@@ -188,14 +188,14 @@ void CarStatusService::Run()
                 ESP_LOGD(GetName().c_str(), "Parando o robô");
                 status->encreading->setData(false);
                 status->robotState->setData(CAR_IN_CURVE);
-                vTaskDelay(500 / portTICK_PERIOD_MS);
+                //vTaskDelay(100 / portTICK_PERIOD_MS);
 
                 // TODO: Encontrar forma bonita de suspender os outros serviços.
                 // vTaskSuspend(xTaskPID);
                 // vTaskSuspend(xTaskSensors);
 
                 robot->getStatus()->robotState->setData(CAR_STOPPED);
-                DataManager::getInstance()->saveAllParamData();
+                DataManager::getInstance()->saveAllParamDataChanged();
                 command.led[0] = LED_POSITION_FRONT;
                 command.led[1] = LED_POSITION_NONE;
                 command.color = LED_COLOR_BLACK;
@@ -220,16 +220,31 @@ void CarStatusService::Run()
                         // Verifica se o robô precisa reduzir a velocidade, entrando no modo curva
                         if((CarState)latMarks->marks->getData(mark).MapStatus == CAR_IN_CURVE && (CarState)latMarks->marks->getData(mark + 1).MapStatus == CAR_IN_LINE)
                         {
-                            if((Manualmedia + pulsesAfterCurve) < ManualmediaNxt && (mediaEncActual - initialmediaEnc) < (Manualmedia + pulsesAfterCurve)) trackType = CAR_IN_CURVE;
-                            else if((Manualmedia + pulsesAfterCurve) >= ManualmediaNxt) trackType = CAR_IN_CURVE;
+                            if((Manualmedia + pulsesAfterCurve) < ManualmediaNxt && (mediaEncActual - initialmediaEnc) < (Manualmedia + pulsesAfterCurve)) 
+                            {
+                                trackType = CAR_IN_CURVE;
+                                trackLen = (TrackState)latMarks->marks->getData(mark).MapTrackStatus;
+                            }
+                            else if((Manualmedia + pulsesAfterCurve) >= ManualmediaNxt) 
+                            {
+                                trackType = CAR_IN_CURVE;
+                                trackLen = (TrackState)latMarks->marks->getData(mark).MapTrackStatus;
+                            }
                         }
                         if(mark + 2 < numMarks)
                         {
                             if((CarState)latMarks->marks->getData(mark+1).MapStatus == CAR_IN_LINE && (CarState)latMarks->marks->getData(mark + 2).MapStatus == CAR_IN_CURVE)
                             {
-                                if((ManualmediaNxt - pulsesBeforeCurve) > Manualmedia && (mediaEncActual - initialmediaEnc) > (ManualmediaNxt - pulsesBeforeCurve)) trackType = CAR_IN_CURVE;
-                                else if((ManualmediaNxt - pulsesBeforeCurve) <= Manualmedia) trackType = CAR_IN_CURVE;
-
+                                if((ManualmediaNxt - pulsesBeforeCurve) > Manualmedia && (mediaEncActual - initialmediaEnc) > (ManualmediaNxt - pulsesBeforeCurve)) 
+                                {
+                                    trackType = CAR_IN_CURVE;
+                                    trackLen = (TrackState)latMarks->marks->getData(mark+2).MapTrackStatus;
+                                }
+                                else if((ManualmediaNxt - pulsesBeforeCurve) <= Manualmedia) 
+                                {
+                                    trackType = CAR_IN_CURVE;
+                                    trackLen = (TrackState)latMarks->marks->getData(mark+2).MapTrackStatus;
+                                }
                             }
                         }
                         // Atualiza estado do robô

--- a/modules/robot/services/CarStatusService/src/CarStatusService.cpp
+++ b/modules/robot/services/CarStatusService/src/CarStatusService.cpp
@@ -195,6 +195,7 @@ void CarStatusService::Run()
                 // vTaskSuspend(xTaskSensors);
 
                 robot->getStatus()->robotState->setData(CAR_STOPPED);
+                DataManager::getInstance()->saveAllParamData();
                 command.led[0] = LED_POSITION_FRONT;
                 command.led[1] = LED_POSITION_NONE;
                 command.color = LED_COLOR_BLACK;

--- a/modules/robot/services/MappingService/src/MappingService.cpp
+++ b/modules/robot/services/MappingService/src/MappingService.cpp
@@ -54,6 +54,7 @@ esp_err_t MappingService::stopNewMapping()
     status->stateMutex.lock();
     status->robotState->setData(CAR_STOPPED);
     status->robotIsMapping->setData(false);
+    DataManager::getInstance()->saveAllParamData();
     status->stateMutex.unlock();
     command.led[0] = LED_POSITION_FRONT;
     command.led[1] = LED_POSITION_NONE;

--- a/modules/robot/services/MappingService/src/MappingService.cpp
+++ b/modules/robot/services/MappingService/src/MappingService.cpp
@@ -16,7 +16,7 @@ MappingService::MappingService(std::string name, uint32_t stackDepth, UBaseType_
     status = robot->getStatus();
 };
 
-esp_err_t MappingService::startNewMapping(uint8_t leftMarksToStop, int32_t mediaPulsesToStop, uint32_t timeToStop)
+esp_err_t MappingService::startNewMapping(uint16_t leftMarksToStop, int32_t mediaPulsesToStop, uint32_t timeToStop)
 {
     ESP_LOGD(GetName().c_str(), "Iniciando novo mapeamento.");
 
@@ -54,19 +54,19 @@ esp_err_t MappingService::stopNewMapping()
     status->stateMutex.lock();
     status->robotState->setData(CAR_STOPPED);
     status->robotIsMapping->setData(false);
-    DataManager::getInstance()->saveAllParamData();
+    DataManager::getInstance()->saveAllParamDataChanged();
     status->stateMutex.unlock();
+
+    this->Cleanup();
+
+    this->saveMapping();
+    ESP_LOGD(GetName().c_str(), "Parada do novo mapeamento finalizada");
     command.led[0] = LED_POSITION_FRONT;
     command.led[1] = LED_POSITION_NONE;
     command.color = LED_COLOR_BLACK;
     command.effect = LED_EFFECT_SET;
     command.brightness = 1;
     LEDsService::getInstance()->queueCommand(command);
-
-    this->Cleanup();
-
-    this->saveMapping();
-    ESP_LOGD(GetName().c_str(), "Parada do novo mapeamento finalizada");
     return ESP_OK;
 }
 

--- a/modules/robot/services/MappingService/src/MappingService.hpp
+++ b/modules/robot/services/MappingService/src/MappingService.hpp
@@ -27,7 +27,7 @@ public:
     
     void Run() override;
 
-    esp_err_t startNewMapping(uint8_t leftMarksToStop = CHAR_MAX, int32_t mediaPulsesToStop = LONG_MAX, uint32_t timeToStop = (portMAX_DELAY / portTICK_PERIOD_MS));
+    esp_err_t startNewMapping(uint16_t leftMarksToStop = INT16_MAX, int32_t mediaPulsesToStop = LONG_MAX, uint32_t timeToStop = (portMAX_DELAY / portTICK_PERIOD_MS));
     esp_err_t stopNewMapping();
 
     esp_err_t loadMapping();
@@ -48,8 +48,8 @@ private:
     struct MapData tempPreviousMark;
 
     // atributos de filtro
-    uint8_t leftMarksToStop;
-    uint8_t rightMarksToStop;
+    uint16_t leftMarksToStop;
+    uint16_t rightMarksToStop;
     int32_t mediaPulsesToStop;
     TickType_t ticksToStop;
 

--- a/modules/robot/services/SpeedService/src/SpeedService.cpp
+++ b/modules/robot/services/SpeedService/src/SpeedService.cpp
@@ -6,8 +6,9 @@ SpeedService::SpeedService(std::string name, uint32_t stackDepth, UBaseType_t pr
     this->speed = robot->getSpeed();
 
     // GPIOs dos encoders dos encoders dos motores
-    enc_motEsq.attachFullQuad(ENC_MOT_ESQ_A, ENC_MOT_ESQ_B);
-    enc_motDir.attachFullQuad(ENC_MOT_DIR_A, ENC_MOT_DIR_B);
+    enc_motEsq.attachFullQuad(ENC_MOT_ESQ_B, ENC_MOT_ESQ_A);
+    enc_motDir.attachFullQuad(ENC_MOT_DIR_B, ENC_MOT_DIR_A);
+    MPR_Mot = speed->MPR->getData();
 };
 
 void SpeedService::Run()
@@ -45,7 +46,7 @@ void SpeedService::Run()
         // Calculos de velocidade instantanea (RPM)
         speed->RPMLeft_inst->setData(                   // -> Calculo velocidade instantanea motor esquerdo
             (((enc_motEsq.getCount() - lastPulseLeft)   // Delta de pulsos do encoder esquerdo
-              / (float)MPR_MotEsq)                      // Conversao para revolucoes de acordo com caixa de reducao e pulsos/rev
+              / (float)MPR_Mot)                      // Conversao para revolucoes de acordo com caixa de reducao e pulsos/rev
              / ((float)deltaTimeMS_inst / (float)60000) // Divisao do delta tempo em minutos para calculo de RPM
              ));
         lastPulseLeft = enc_motEsq.getCount();  // Salva pulsos do encoder para ser usado no proximo calculo
@@ -53,7 +54,7 @@ void SpeedService::Run()
 
         speed->RPMRight_inst->setData(                  // -> Calculo velocidade instantanea motor direito
             (((enc_motDir.getCount() - lastPulseRight)  // Delta de pulsos do encoder esquerdo
-              / (float)MPR_MotDir)                      // Conversao para revolucoes de acordo com caixa de reducao e pulsos/rev
+              / (float)MPR_Mot)                      // Conversao para revolucoes de acordo com caixa de reducao e pulsos/rev
              / ((float)deltaTimeMS_inst / (float)60000) // Divisao do delta tempo em minutos para calculo de RPM
              ));
         lastPulseRight = enc_motDir.getCount();   // Salva pulsos do motor para ser usado no proximo calculo
@@ -65,12 +66,13 @@ void SpeedService::Run()
             / ((float)deltaTimeMS_media / (float)60000)                                                            // Divisao do delta tempo em minutos para calculo de RPM
         );
 
-        // if (iloop >= 100)
-        // {
-        //     ESP_LOGD(GetName().c_str(), "encDir: %d | encEsq: %d", enc_motDir.getCount(), enc_motEsq.getCount());
-        //     ESP_LOGD(GetName().c_str(), "Soma: %d - VelEncDir: %d | VelEncEsq: %d", (speed->RPMRight_inst->getData() + speed->RPMLeft_inst->getData()), speed->RPMRight_inst->getData(), speed->RPMLeft_inst->getData());
-        //     iloop = 0;
-        // }
-        // iloop++;
+        if (iloop >= 100)
+        {
+            ESP_LOGD(GetName().c_str(), "encDir: %d | encEsq: %d", enc_motDir.getCount(), enc_motEsq.getCount());
+            ESP_LOGD(GetName().c_str(), "Soma: %d - VelEncDir: %d | VelEncEsq: %d", (speed->RPMRight_inst->getData() + speed->RPMLeft_inst->getData()), speed->RPMRight_inst->getData(), speed->RPMLeft_inst->getData());
+            ESP_LOGD(GetName().c_str(), "MPR: %d",speed->MPR->getData());
+            iloop = 0;
+        }
+        iloop++;
     }
 }

--- a/modules/robot/services/SpeedService/src/SpeedService.hpp
+++ b/modules/robot/services/SpeedService/src/SpeedService.hpp
@@ -29,9 +29,7 @@ private:
     ESP32Encoder enc_motDir;
 
     short const TaskDelay = 10; // 10 ms
-    uint16_t const MPR_MotEsq = 120;
-    uint16_t const MPR_MotDir = 120;
-
+    uint16_t MPR_Mot = 180;
     TickType_t lastTicksRevsCalc = 0;
     int32_t lastPulseRight = 0;
     int32_t lastPulseLeft = 0;


### PR DESCRIPTION
Estávamos passando por travamentos do robô durante a alteração dos dados.

O @Matheus-de-Sousa adicionou uma lógica para fazer operações na memória flash somente quando o robô está parado, significa que os parâmetros só serão salvos na memória flash (memória permanente) quando o robô estiver parado, ou a operação for forçada pelo usuário.